### PR TITLE
[FIX] showing who is the host in waiting room (issue #102)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -91,7 +91,7 @@ io.on("connection", (socket) => {
       socket.emit("room-created", { code, rooms: Object.fromEntries(rooms.entries()) });
     }
   });
-
+  
   // join room event
   socket.on("join", ({ code, playerName, avatar }) => {
     console.log(`${playerName} attempting to join room ${code}`);
@@ -161,7 +161,8 @@ io.on("connection", (socket) => {
       players: room.players,
       maxPlayers: room.maxPlayers,
       amountOfPlayersInRoom: room.settings.amountOfPlayers, // default to 8 if not set,
-      playerScores: Array.from(room.playerScores.values())
+      playerScores: Array.from(room.playerScores.values()),
+      host: room.host 
     });
     
     // Send current scores to the new player
@@ -182,18 +183,20 @@ io.on("connection", (socket) => {
         isIntermission: !!room.isIntermission,
         roundStartTime: room.roundStartTime,
         players: room.players,
-        playerScores: Array.from(room.playerScores.values())
+        playerScores: Array.from(room.playerScores.values()),
+        host: room.host
       });
       return;
     } else {
       // Game hasn't started - normal waiting room flow
       socket.emit("join-success", { 
         players: room.players,
-        amountOfPlayersInRoom: room.maxPlayers
+        amountOfPlayersInRoom: room.maxPlayers,
+        host: room.host
       });
     }
   });
-
+  
   socket.on('get-room-players-scores', ( code ) => {
     socket.join(code);
 
@@ -272,7 +275,7 @@ io.on("connection", (socket) => {
       room.roundStartTime = null;
       
       const settings = room.settings;
-      io.to(code).emit("game-started", settings);
+      io.to(code).emit("game-started", { ...settings, host: room.host });
       console.log(`Game started in room ${code}`);
     }
   });
@@ -420,7 +423,8 @@ io.on("connection", (socket) => {
         // Update remaining players
         io.to(socket.roomCode).emit("players-updated", { 
           players: room.players, 
-          maxPlayers: room.maxPlayers 
+          maxPlayers: room.maxPlayers,
+          host: room.host
         });
         
         // Clean up empty rooms

--- a/frontend/src/pages/WaitingRoom.tsx
+++ b/frontend/src/pages/WaitingRoom.tsx
@@ -33,6 +33,9 @@ const WaitingRoom: React.FC = () => {
   const [players, setPlayers] = useState<PlayerObj[]>([]);
   const [amountOfPlayersInRoom, setAmountOfPlayersInRoom] = useState(0);
 
+  // Track host name so everyone can see who the host is
+  const [hostName, setHostName] = useState<string | null>(null);
+
   // If a player joins mid-round, keep them in this waiting room and show banner
   const [activeGameInfo, setActiveGameInfo] = useState<any | null>(null);
   // Keep a ref so socket handlers always use the latest settings
@@ -51,16 +54,22 @@ const WaitingRoom: React.FC = () => {
     });
 
     // Handle successful join
-    socket.on("join-success", ({ playerScores, amountOfPlayersInRoom }) => {
+    socket.on("join-success", ({ playerScores, amountOfPlayersInRoom, host }) => {
       // server sends full player score objects; use them to render avatars and names
       if (Array.isArray(playerScores)) {
         setPlayers(playerScores);
       }
       setAmountOfPlayersInRoom(amountOfPlayersInRoom);
+      if (host) setHostName(host);
     });
 
     // Add this handler for joining active games
     socket.on("join-active-game", (gameSettings) => {
+      // capture host when provided
+      if (gameSettings?.host) {
+        setHostName(gameSettings.host);
+      }
+
       // If a round is active, keep the joining client in the waiting room and show banner.
       // Store the full game settings so we can merge them with subsequent round events.
       if (gameSettings?.isRoundActive) {
@@ -79,6 +88,9 @@ const WaitingRoom: React.FC = () => {
     });
 
     socket.on("game-started", (settings) => {  
+      // capture host if provided
+      if (settings?.host) setHostName(settings.host);
+
       navigate(`/room/${code}`, {
         state: {
           ...settings,
@@ -161,7 +173,7 @@ const WaitingRoom: React.FC = () => {
           {amountOfPlayersInRoom === 1 ? (
             <div className="single-player">
               <div className={`player-item ${players[0]?.name === playerName ? 'current-player' : ''}`}>
-                {players[0]?.name ?? playerName} {players[0]?.name === playerName && isHost ? '(Host)' : ''}
+                {players[0]?.name ?? playerName} {players[0]?.name === hostName ? '(Host)' : ''} {players[0]?.name === playerName && isHost ? '(You / Host)' : ''}
               </div>
             </div>
           ) : (
@@ -183,7 +195,7 @@ const WaitingRoom: React.FC = () => {
                     }}>
                       <img src={avatarSrc} alt={`${player.name} avatar`} style={{ width: 28, height: 28, borderRadius: "50%" }} />
                     </div>
-                    {player.name} {player.name === playerName && isHost ? '(Host)' : ''}
+                    {player.name} {player.name === hostName ? '(Host)' : ''}
                   </li>
                 );
               })}


### PR DESCRIPTION
### #102 Showing who the host is
**Changes made**
Fix the "(host)" not appearing in non-host players' waiting room. Added send host name in server events and compare players' names against it to determine who is the host.
- (host) after host's name shows in all players' waiting rooms when starting the game
- (host) shows in waiting room for late joiners

**When testing this pull request**
Test for both the initial waiting room before starting the game and joining late.